### PR TITLE
Updated djangorestframework version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/tomchristie/django-rest-framework/@master#egg=rest_framework==2.3.13
+djangorestframework==2.4.4
 django==1.5.1
 Pygments==1.5
 Markdown==2.2.0


### PR DESCRIPTION
I had problems doing the tutorial with the other version from the requirements.txt and upgrading it solved the problems.

This is the error that I was getting while importing `serializers`

```
AttributeError: 'module' object has no attribute 'add_metaclass' 
```
