### PR TITLE
Remove unused view imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Django==2.1.7
 Pygments==2.3.1
 Markdown==3.1
 coreapi==2.3.3
-psycopg2==2.7.7
+psycopg2-binary==2.7.7
 dj-database-url==0.5.0
 gunicorn==19.9.0
 whitenoise==4.1.2

--- a/snippets/views.py
+++ b/snippets/views.py
@@ -1,8 +1,7 @@
 from django.contrib.auth.models import User
-from rest_framework import generics, permissions, renderers, viewsets
-from rest_framework.decorators import api_view, detail_route
+from rest_framework import permissions, renderers, viewsets
+from rest_framework.decorators import detail_route
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
 
 from snippets.models import Snippet
 from snippets.permissions import IsOwnerOrReadOnly


### PR DESCRIPTION
1. Removed unused imports from `views.py`
2. Updated `psycopg2` to `psycopg2-binary` to remove warnings messages

Do we even need psycopg2 for this tutorial?