### PR TITLE
missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psycopg2-binary==2.7.7
 dj-database-url==0.5.0
 gunicorn==19.9.0
 whitenoise==4.1.2
+PyYAML==5.1


### PR DESCRIPTION
Fixes this bug : AssertionError at /schema/
Using OpenAPIRenderer, but `pyyaml` is not installed.