### PR TITLE
'AutoSchema' object has no attribute 'get_link' #71

### DIFF
--- a/tutorial/settings.py
+++ b/tutorial/settings.py
@@ -130,6 +130,8 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 10,
     'DEFAULT_PAGINATION_CLASS':
     'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
+
 }
 
 if ENVIRONMENT == 'production':


### PR DESCRIPTION
Fix: add AutoSchema config on settings.py

This PR is the fixed code of the issue #71 